### PR TITLE
Adding scheduled job thread to clean cache

### DIFF
--- a/audit.go
+++ b/audit.go
@@ -357,6 +357,12 @@ func main() {
 		filters,
 	)
 
+	//Initialize the container utils
+	err = cu.Init()
+	if nil != err {
+		el.Fatal(err)
+	}
+
 	l.Printf("Started processing events in the range [%d, %d]\n", config.GetInt("events.min"), config.GetInt("events.max"))
 
 	//Main loop. Get data from netlink and send it to the json lib for processing

--- a/container-helper/ContainerHelper.go
+++ b/container-helper/ContainerHelper.go
@@ -16,6 +16,10 @@ func NewContainerUtil() ContainerUtil {
 	}
 }
 
+func (cu ContainerUtil) Init() error {
+	return cu.pidCache.Init()
+}
+
 func (cu ContainerUtil) GetContainerId(pid int) (int, error) {
 
 	cid, err := cu.pidCache.Get(pid)


### PR DESCRIPTION
 - Cleaning up all the closed PIDs from the cache
 - This is done in a scheduled job that runs once a minute in a separate thread.